### PR TITLE
Cache GetUpdateChain requests

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -61,17 +61,17 @@ import defaultRoster from './default-roster'
 import { bytes2Hex } from './utils'
 import { version } from '../package.json'
 
-const STORE_KEY_SKIPCHAINS = 'dedis_cache_skipchains';
+const STORE_KEY_SKIPCHAINS = 'dedis_cache_skipchains'
 
 export default {
   name: 'App',
   components: { 'Explorer': Explorer, 'UserRoster': UserRoster },
   data () {
-    let skipchains = [];
+    let skipchains = []
     try {
-      const cache = localStorage.getItem(STORE_KEY_SKIPCHAINS);
-      skipchains = JSON.parse(cache) || [];
-    } catch(e) {
+      const cache = window.localStorage.getItem(STORE_KEY_SKIPCHAINS)
+      skipchains = JSON.parse(cache) || []
+    } catch (e) {
       // not set, ignoring the error
     }
 
@@ -126,7 +126,7 @@ export default {
       this.socket.getAllSkipChainIDs().then(
         (ids) => {
           this.skipchains = ids.map(bytes2Hex)
-          localStorage.setItem(STORE_KEY_SKIPCHAINS, JSON.stringify(this.skipchains))
+          window.localStorage.setItem(STORE_KEY_SKIPCHAINS, JSON.stringify(this.skipchains))
 
           if (this.skipchains.length >= 1 && !this.$route.params.chain) {
             console.log('auto choose 1st skipchain')

--- a/src/App.vue
+++ b/src/App.vue
@@ -61,10 +61,20 @@ import defaultRoster from './default-roster'
 import { bytes2Hex } from './utils'
 import { version } from '../package.json'
 
+const STORE_KEY_SKIPCHAINS = 'dedis_cache_skipchains';
+
 export default {
   name: 'App',
   components: { 'Explorer': Explorer, 'UserRoster': UserRoster },
   data () {
+    let skipchains = [];
+    try {
+      const cache = localStorage.getItem(STORE_KEY_SKIPCHAINS);
+      skipchains = JSON.parse(cache) || [];
+    } catch(e) {
+      // not set, ignoring the error
+    }
+
     return {
       version,
       clipped: false,
@@ -80,7 +90,7 @@ export default {
       title: 'SkipChain Explorer',
       socket: null,
       blocks: [],
-      skipchains: [],
+      skipchains,
       chosenSkipchain: this.$route.params.chain
     }
   },
@@ -109,13 +119,15 @@ export default {
     },
 
     connectToCothority: function (ro) {
-      const roster = Roster.fromTOML(ro)
-      const socket = new SkipchainRPC(roster)
+      this.roster = Roster.fromTOML(ro)
+      this.socket = new SkipchainRPC(this.roster)
 
       /* get all skipchains IDs and map each of them to its hexadecimal form */
-      socket.getAllSkipChainIDs().then(
+      this.socket.getAllSkipChainIDs().then(
         (ids) => {
           this.skipchains = ids.map(bytes2Hex)
+          localStorage.setItem(STORE_KEY_SKIPCHAINS, JSON.stringify(this.skipchains))
+
           if (this.skipchains.length >= 1 && !this.$route.params.chain) {
             console.log('auto choose 1st skipchain')
             this.chooseSkipchain(this.skipchains[0], 'status')
@@ -125,9 +137,6 @@ export default {
           console.log('could not get all skipchains', e)
         }
       )
-
-      this.roster = roster
-      this.socket = socket
     }
   }
 }

--- a/src/Explorer.vue
+++ b/src/Explorer.vue
@@ -19,7 +19,7 @@ const REGEX_SKIPCHAIN_ID = /^dedis_cache_[0-9a-f]+$/
 
 /**
  * Encode the blocks as a string and store them at the given index which
- * is the ID of the skipchain
+ * is the ID of the skipchain.
  *
  * @param {string} id               The ID of the skipchain
  * @param {Array<SkipBlock>} blocks The list of blocks to store
@@ -59,9 +59,9 @@ function storeBlocks (id, blocks) {
 }
 
 /**
- * load the blocks from the local storage at the given index which
+ * Loads the blocks from the local storage at the given index which
  * is the skipchain ID. It returns an empty array when it doesn't
- * exist or is occrupted.
+ * exist or is corrupted.
  *
  * @param {string} id The skipchain ID
  * @returns {Array<SkipBlock>}

--- a/src/components/BlockInfo.vue
+++ b/src/components/BlockInfo.vue
@@ -105,7 +105,6 @@ import Roster from './Roster'
 import ByzcoinPayload from './ByzcoinPayload'
 import ByzcoinData from './ByzcoinData'
 import Verifier from './Verifier'
-import { SkipchainRPC } from '@dedis/cothority/skipchain'
 
 export default {
   props: ['blocks', 'socket', 'getBlockByIndex', 'getBlockByHash'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -225,11 +225,6 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@<7.4.0":
-  version "7.3.4"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.3.4.tgz#a43357e4bbf4b92a437fb9e465c192848287f27c"
-  integrity sha512-tXZCqWtlOOP4wgCp6RjRvLmfuhnqTLy9VHwRochJBCP2nDm27JnnuFEnXFASVyQNHk36jD1tAammsCEEqgscIQ==
-
 "@babel/parser@^7.0.0", "@babel/parser@^7.4.0":
   version "7.4.2"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.4.2.tgz#b4521a400cb5a871eab3890787b4bc1326d38d91"

--- a/yarn.lock
+++ b/yarn.lock
@@ -225,6 +225,11 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
+"@babel/parser@<7.4.0":
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.3.4.tgz#a43357e4bbf4b92a437fb9e465c192848287f27c"
+  integrity sha512-tXZCqWtlOOP4wgCp6RjRvLmfuhnqTLy9VHwRochJBCP2nDm27JnnuFEnXFASVyQNHk36jD1tAammsCEEqgscIQ==
+
 "@babel/parser@^7.0.0", "@babel/parser@^7.4.0":
   version "7.4.2"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.4.2.tgz#b4521a400cb5a871eab3890787b4bc1326d38d91"


### PR DESCRIPTION
This caches the GetUpdateChain and AllSkipchainIDs requests so that the requests are not repeated multiple times. The update only tries to get the blocks from the latest _known_ block.

Fixes #12 